### PR TITLE
CMakeLists.txt update and compilation on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,6 @@ SET(RUNTIME_OUTPUT_DIRECTORY ${scream_SOURCE_DIR}/bin)
 
 SET(scream_BIN ${scream_SOURCE_DIR}/bin)
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg")
-SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pg")
-SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pg")
-
 message("scream_SOURCE_DIR directories:" ${scream_SOURCE_DIR})
 
 IF(UNIX)
@@ -30,6 +26,9 @@ set(MSVC_VER VC11)
 ELSEIF(MSVC10)
 message("Detected MSVC10 compiler")
 set(MSVC_VER VC10)
+ELSEIF(MSVC14)
+message("Detected MSVC14 compiler")
+set(MSVC_VER VC14)
 ELSE(MSVC12)
 message("WARNING: Unknown/unsupported MSVC version")
 ENDIF(MSVC12)

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -20,18 +20,6 @@ ${SRCS}
 scream_01.cpp
 )
 
-SET(SRC_2
-${SRCS}
-scream_02.cpp
-)
-
-SET(SRC_3
-${SRCS}
-scream_03.cpp
-)
-
-
-
 INCLUDE_DIRECTORIES(
 ${screamIncludes}
 )
@@ -41,21 +29,8 @@ ${screamLink}
 )
 
 ADD_EXECUTABLE(scream_01 ${SRC_1} ${HEADERS})
-ADD_EXECUTABLE(scream_02 ${SRC_2} ${HEADERS})
-ADD_EXECUTABLE(scream_03 ${SRC_3} ${HEADERS})
 
 TARGET_LINK_LIBRARIES (
 scream_01
 ${screamLibs}
 )
-
-TARGET_LINK_LIBRARIES (
-scream_02
-${screamLibs}
-)
-
-TARGET_LINK_LIBRARIES (
-scream_03
-${screamLibs}
-)
-

--- a/code/scream_01.cpp
+++ b/code/scream_01.cpp
@@ -7,18 +7,14 @@
 #include "NetQueue.h"
 #include "ScreamTx.h"
 #include "ScreamRx.h"
-#include <iostream>
-#include <windows.h>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
+
 using namespace std;
 
 const float Tmax = 50.0f;
 const bool testLowBitrate = false;
 const bool isChRate = false;
 
-int _tmain(int argc, _TCHAR* argv[])
+int main(int argc, char* argv[])
 {
 
     uint64_t rtcpFbInterval_us;
@@ -61,7 +57,7 @@ int _tmain(int argc, _TCHAR* argv[])
     int size;
     uint16_t seqNr;
     int nextCallN = -1;
-    bool isFeedback = FALSE;
+    bool isFeedback = false;
 
     while (time <= Tmax) {
         float retVal = -1.0;
@@ -70,7 +66,7 @@ int _tmain(int argc, _TCHAR* argv[])
         time_us_tx = time_us+000000;
         time_us_rx = time_us+000000;
 
-        bool isEvent = FALSE;
+        bool isEvent = false;
 
         if (n % videoTick == 0) {
             // "Encode" video frame
@@ -81,7 +77,7 @@ int _tmain(int argc, _TCHAR* argv[])
             * New RTP packets added, try if OK to transmit
             */
             retVal = screamTx->isOkToTransmit(time_us_tx, ssrc);
-            isEvent = TRUE;
+            isEvent = true;
         }
 
         if (netQueueRate->extract(time, rtpPacket, ssrc, size, seqNr)) {
@@ -103,10 +99,10 @@ int _tmain(int argc, _TCHAR* argv[])
         if (isFeedback && (time_us_rx - screamRx->getLastFeedbackT() > rtcpFbInterval_us)) {
 			if (screamRx->getFeedback(time_us_rx, ssrc, rxTimestamp, aseqNr, aackVector)) {
 				//cerr << rxTimestamp << " " << aseqNr << endl;
-				screamTx->incomingFeedback(time_us_tx, ssrc, rxTimestamp, aseqNr, aackVector, FALSE);
+				screamTx->incomingFeedback(time_us_tx, ssrc, rxTimestamp, aseqNr, aackVector, false);
                 retVal = screamTx->isOkToTransmit(time_us_tx, ssrc);
-                isFeedback = FALSE;
-                isEvent = TRUE;
+                isFeedback = false;
+                isEvent = true;
             }
         }
 
@@ -114,7 +110,7 @@ int _tmain(int argc, _TCHAR* argv[])
             retVal = screamTx->isOkToTransmit(time_us_tx, ssrc);
             if (retVal > 0) {
                 nextCallN = n + max(1,(int)(1000.0*retVal));
-                isEvent = TRUE;
+                isEvent = true;
             }
         }
         if (retVal == 0) {
@@ -125,7 +121,7 @@ int _tmain(int argc, _TCHAR* argv[])
             netQueueRate->insert(time,rtpPacket, ssrc, size, seqNr);
             retVal = screamTx->addTransmitted(time_us_tx, ssrc, size, seqNr);
             nextCallN = n + max(1,(int)(1000.0*retVal));
-            isEvent = TRUE;
+            isEvent = true;
         }
 
         if (true && isEvent) {
@@ -147,7 +143,11 @@ int _tmain(int argc, _TCHAR* argv[])
                 netQueueRate->rate = 2000e3;
 
         n++;
+#ifdef _WIN32
         Sleep(0) ;
+#else
+        sleep(0);
+#endif
     }
 
     return 0;

--- a/code/stdafx.h
+++ b/code/stdafx.h
@@ -5,11 +5,17 @@
 
 #pragma once
 
+#ifdef _WIN32
 #include "targetver.h"
-
-#include <stdio.h>
 #include <tchar.h>
-
-
+#include <windows.h>
+#else
+#include "unistd.h" // for sleep
+#endif
 
 // TODO: reference additional headers your program requires here
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+


### PR DESCRIPTION
Hi Ingemar,

Removed the old projects (scream02 and scream03) from CMakeLists.txt, some minor clean-up and made the code compilable on linux.

Compiled and tested CMake with VC2015 on WIndows and g++ 4.9.1 on linux.

Still need to look at compiler warnings under VC2015:

FYI:
2>E:\projects\pullrequest\scream_pull\code\ScreamRx.cpp(55): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
2>E:\projects\pullrequest\scream_pull\code\ScreamRx.cpp(66): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
2>  ScreamTx.cpp
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(251): warning C4244: 'return': conversion from 'double' to 'float', possible loss of data
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(416): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(528): warning C4244: 'argument': conversion from 'double' to 'float', possible loss of data
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(791): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(827): warning C4244: 'initializing': conversion from 'double' to 'float', possible loss of data
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(854): warning C4305: '*=': truncation from 'double' to 'float'
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(872): warning C4244: '*=': conversion from 'double' to 'float', possible loss of data
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(1107): warning C4244: '=': conversion from 'double' to 'float', possible loss of data
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(1109): warning C4305: '*=': truncation from 'double' to 'float'
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(1157): warning C4244: 'initializing': conversion from 'double' to 'float', possible loss of data
2>E:\projects\pullrequest\scream_pull\code\ScreamTx.cpp(1163): warning C4244: 'initializing': conversion from 'float' to 'int', possible loss of data
2>  VideoEnc.cpp
2>E:\projects\pullrequest\scream_pull\code\VideoEnc.cpp(13): warning C4838: conversion from 'double' to 'const float' requires a narrowing conversion
2>E:\projects\pullrequest\scream_pull\code\VideoEnc.cpp(13): warning C4305: 'initializing': truncation from 'double' to 'const float'
2>E:\projects\pullrequest\scream_pull\code\VideoEnc.cpp(50): warning C4244: '*=': conversion from 'double' to 'float', possible loss of data
2>E:\projects\pullrequest\scream_pull\code\VideoEnc.cpp(74): warning C4244: '*=': conversion from 'const float' to 'int', possible loss of data
