### PR TITLE
ScreamTx.cpp: add header <cmath> for function sqrt

### DIFF
--- a/code/ScreamTx.cpp
+++ b/code/ScreamTx.cpp
@@ -2,6 +2,7 @@
 #include "ScreamTx.h"
 #include "ScreamRx.h"
 #include <cstdint>
+#include <cmath>
 #include <string.h>
 #include <iostream>
 #include <algorithm>


### PR DESCRIPTION
Function `sqrt` requires the header `<math.h>` or `<cmath>` (tested with GCC 6.3.0). Even though in some versions of GCC, the header may not be required since GCC provides built-in functions.