### PR TITLE
Add RtpQueue interface + some helper methods + updateable min/max bitrates

### DIFF
--- a/code/RtpQueue.h
+++ b/code/RtpQueue.h
@@ -6,6 +6,17 @@
 * per stream {SSRC,PT}
 */
 
+class RtpQueueIface {
+public:
+    virtual void clear() = 0;
+    virtual int sizeOfNextRtp() = 0;
+    virtual int seqNrOfNextRtp() = 0;
+    virtual int bytesInQueue() = 0; // Number of bytes in queue
+    virtual int sizeOfQueue() = 0;  // Number of items in queue
+    virtual float getDelay(float currTs) = 0;
+    virtual int getSizeOfLastFrame() = 0;
+};
+
 class RtpQueueItem {
 public:
     RtpQueueItem();
@@ -17,7 +28,7 @@ public:
 };
 
 const int RtpQueueSize = 20000;
-class RtpQueue {
+class RtpQueue : public RtpQueueIface {
 public:
     RtpQueue();
 

--- a/code/ScreamTx.cpp
+++ b/code/ScreamTx.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
+
 using namespace std;
 
 // === Some good to have features, SCReAM works also
@@ -149,7 +151,7 @@ ScreamTx::~ScreamTx() {
 /*
 * Register new stream
 */
-void ScreamTx::registerNewStream(RtpQueue *rtpQueue,
+void ScreamTx::registerNewStream(RtpQueueIface *rtpQueue,
     uint32_t ssrc,
     float priority,
     float minBitrate,
@@ -174,6 +176,20 @@ void ScreamTx::registerNewStream(RtpQueue *rtpQueue,
         lossEventRateScale);
     streams[nStreams++] = stream;
 }
+
+void ScreamTx::updateBitrateStream(uint32_t ssrc,
+                         float minBitrate,
+                         float maxBitrate) {
+    Stream *stream = getStream(ssrc);
+    stream->minBitrate = minBitrate;
+    stream->maxBitrate = maxBitrate;
+}
+
+RtpQueueIface * ScreamTx::getStreamQueue(uint32_t ssrc) {
+    Stream* stream = getStream(ssrc);
+    return stream->rtpQueue;
+}
+
 
 /*
 * New media frame
@@ -597,7 +613,7 @@ void ScreamTx::initialize(uint64_t time_us) {
 }
 
 ScreamTx::Stream::Stream(ScreamTx *parent_,
-    RtpQueue *rtpQueue_,
+    RtpQueueIface *rtpQueue_,
     uint32_t ssrc_,
     float priority_,
     float minBitrate_,


### PR DESCRIPTION
# RtpQueue Interface

To simplify the integration in some applications it is desirable to have more flexibility in the way the RtpQueue stores the messages.  For example in my case I want to maintain a list of smart pointers owning the memory instead of a list of raw pointers.

# Updateable min/max bitrate

In some cases it is required to change the max bitrate on the fly.  For example in a conferencing scenario depending on the number of participants.   This PR adds the method updateBitrateStream

# Small issues
* Missing include <math.h>
* Make getSRtt public to include that information in the app logging/metrics
* New getStreamQueue method to access the packets queue when needed without having to maintain an additional reference in the application when you already have it in ScreamTx stream.