### PR TITLE
Fix compiling issues with the sample code.

### DIFF
--- a/code/RtpQueue.cpp
+++ b/code/RtpQueue.cpp
@@ -102,16 +102,16 @@ float RtpQueue::getDelay(float currTs) {
         return currTs-items[tail]->ts;
     }
 }
-/*
+
 bool RtpQueue::sendPacket(void *rtpPacket, int& size, unsigned short& seqNr) {
     if (sizeOfQueue() > 0) {
         bool isMark;
-        pop(rtpPacket, size, seqNr, isMark);
+        pop(&rtpPacket, size, seqNr, isMark);
         return true;
     }
     return false;
 }
-*/
+
 extern void packet_free(void *buf);
 int RtpQueue::clear() {
     uint16_t seqNr;

--- a/code/VideoEnc.cpp
+++ b/code/VideoEnc.cpp
@@ -49,7 +49,7 @@ int VideoEnc::encode(float time) {
         bytes -= rtpSize;
         rtpSize += kRtpOverHead;
         rtpBytes += rtpSize;
-        rtpQueue->push(rtpPacket, rtpSize, seqNr, time);
+        rtpQueue->push(rtpPacket, rtpSize, seqNr, false, time);
         seqNr++;
     }
     rtpQueue->setSizeOfLastFrame(rtpBytes);

--- a/code/wrapper_lib/scream_sender_plugin_wrapper.cpp
+++ b/code/wrapper_lib/scream_sender_plugin_wrapper.cpp
@@ -1,6 +1,6 @@
 // Scream sender side wrapper
-#include "ScreamTx.h"
-#include "RtpQueue.h"
+#include "../ScreamTx.h"
+#include "../RtpQueue.h"
 #include "sys/types.h"
 #include <sys/time.h>
 #include <pthread.h>


### PR DESCRIPTION
@IngJohEricsson I tried to compile the sample code but I got compiling errors. Now with this fix I can compile it as below:

$ g++ scream_v_a.cpp NetQueue.cpp ScreamTx.cpp ScreamRx.cpp RtpQueue.cpp VideoEnc.cpp wrapper_lib/scream_sender_plugin_wrapper.cpp -lpthread

This would be good if all these can be added in the Makefile.
