### PR TITLE
Expose ScreamTx transmit rate as screamtx.transmit-bitrate

### DIFF
--- a/code/ScreamTx.cpp
+++ b/code/ScreamTx.cpp
@@ -1138,8 +1138,13 @@ void ScreamTx::detectLoss(uint32_t time_ntp, struct Transmitted *txPackets, uint
 
 float ScreamTx::getTargetBitrate(uint32_t ssrc) {
 	int id;
-	return  getStream(ssrc, id)->getTargetBitrate();
+	return getStream(ssrc, id)->getTargetBitrate();
 }
+
+float ScreamTx::getTransmitBitrate(uint32_t ssrc) {
+	return statistics->getAvgRateTx() / 1000.0f;
+}
+
 
 void ScreamTx::setTargetPriority(uint32_t ssrc, float priority) {
 	int id;

--- a/code/ScreamTx.h
+++ b/code/ScreamTx.h
@@ -248,6 +248,7 @@ extern "C" {
 		*  request a new key frame from a video encoder
 		*/
 		float getTargetBitrate(uint32_t ssrc);
+		float getTransmitBitrate(uint32_t ssrc);
 
 		/*
 		* Set target priority for a given stream, priority value should be in range ]0.0..1.0]
@@ -416,6 +417,7 @@ extern "C" {
 			Statistics();
 			void getSummary(float time, char s[]);
 			void add(float rateTx, float rateLost, float rtt, float queueDelay);
+			float getAvgRateTx() const { return avgRateTx; }
 		private:
 			float lossRateHist[kLossRateHistSize];
 			float rateLostAcc;

--- a/code/wrapper_lib/screamtx_plugin_wrapper.cpp
+++ b/code/wrapper_lib/screamtx_plugin_wrapper.cpp
@@ -5,6 +5,7 @@
 #include <sys/time.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <cassert>
 
 extern const char *log_tag;
 
@@ -35,9 +36,13 @@ stream_t *getStream(uint32_t ssrc) {
                 }
             }
     }
-    printf("%s %u no stream  ssrc %u \n", __FUNCTION__, __LINE__, ssrc);
- 	return NULL;
+    else {
+	    printf("%s %u stream ssrc 0 is invalid. It must be > 0\n", __FUNCTION__, __LINE__);
+    }
+    printf("%s %u no stream ssrc %u \n", __FUNCTION__, __LINE__, ssrc);
+    return NULL;
 }
+
 static uint32_t cur_n_streams = 0;
 stream_t *addStream(uint32_t ssrc) {
  	for (int n = 0; n < kMaxStreams; n++) {
@@ -49,7 +54,7 @@ stream_t *addStream(uint32_t ssrc) {
  			return &streams[n];
  		}
  	}
-    printf("%s %u can't add  ssrc %u \n", __FUNCTION__, __LINE__, ssrc);
+        printf("%s %u can't add  ssrc %u \n", __FUNCTION__, __LINE__, ssrc);
  	return NULL;
 }
 
@@ -313,6 +318,12 @@ int tx_plugin_main(int argc, char* argv[], uint32_t ssrc)
   t0 = tp.tv_sec + tp.tv_usec*1e-6 - 1e-3;
   lastT_ntp = getTimeInNtp();
 
+  if (stream == nullptr)
+  {
+	  cerr << "ERROR: no stream with ssrc " << ssrc << " found!\n";
+	  exit(0);
+  }
+
   /*
   * Parse command line
   */
@@ -548,6 +559,7 @@ int tx_plugin_main(int argc, char* argv[], uint32_t ssrc)
                               ect==1,
                               false,
                               enableClockDriftCompensation);
+
       screamTx->setCwndMinLow(5000);
       if (logFile) {
           if (append)
@@ -565,7 +577,7 @@ int tx_plugin_main(int argc, char* argv[], uint32_t ssrc)
       pthread_mutex_init(&lock_scream, NULL);
       pthread_mutex_init(&stream->lock_rtp_queue, NULL);
   }
-    stream->rtpQueue = new RtpQueue();
+  stream->rtpQueue = new RtpQueue();
 
   screamTx->registerNewStream(stream->rtpQueue,
                               ssrc,
@@ -712,11 +724,18 @@ uint8_t ScreamSenderRtcpPush(uint8_t*buf_rtcp, uint32_t recvlen) {
     return (1);
 }
 
-void ScreamSenderGetTargetRate (uint32_t ssrc, uint32_t *rate_p, uint32_t *force_idr_p) {
+void ScreamSenderGetTargetRate (uint32_t ssrc, uint32_t *rate_p, uint32_t *force_idr_p, uint32_t *transmit_rate_p) {
     int n = 0;
     *rate_p = 0;
     *force_idr_p = 0;
     stream_t *stream = NULL;
+
+    if (transmit_rate_p)
+    {
+	    float transmitRate = screamTx->getTransmitBitrate(ssrc);
+	    *transmit_rate_p = transmitRate;
+    }
+
     /*
      * Poll rate change for all media sources
      */


### PR DESCRIPTION
We need a way to read the transmit rate from scream when using the rust plugins (screamtx) in order to overlay this information directly on the video using the textoverlay plugin.