### PR TITLE
Synchronize push and pop in the RtpQueue

### DIFF
--- a/code/RtpQueue.cpp
+++ b/code/RtpQueue.cpp
@@ -27,6 +27,7 @@ RtpQueue::RtpQueue() {
 }
 
 bool RtpQueue::push(void* rtpPacket, int size, uint32_t ssrc, unsigned short seqNr, bool isMark, float ts) {
+	std::unique_lock<std::mutex> lock(queue_operation_mutex_);
 	int ix = head + 1;
 	if (ix == kRtpQueueSize) ix = 0;
 	if (items[ix]->used) {
@@ -52,6 +53,7 @@ bool RtpQueue::push(void* rtpPacket, int size, uint32_t ssrc, unsigned short seq
 }
 bool RtpQueue::pop(void** rtpPacket, int& size, uint32_t& ssrc, unsigned short& seqNr, bool& isMark)
 {
+	std::unique_lock<std::mutex> lock(queue_operation_mutex_);
 	if (items[tail]->used == false) {
 		*rtpPacket = NULL;
 		return false;

--- a/code/RtpQueue.h
+++ b/code/RtpQueue.h
@@ -2,6 +2,7 @@
 #define RTP_QUEUE
 
 #include <cstdint>
+#include <mutex>
 /*
 * Implements a simple RTP packet queue, one RTP queue
 * per stream {SSRC,PT}
@@ -59,6 +60,7 @@ public:
 	int bytesInQueue_;
 	int sizeOfQueue_;
 	int sizeOfNextRtp_;
+	std::mutex queue_operation_mutex_;
 };
 
 #endif


### PR DESCRIPTION
We are currently having problem with  your SCREAM application. Our application is using your scream application in the background and runs a lot of parallel streams. It crashes when scream application calls clear() on the queue and our code executes pop() at the same time (same as in scream_sender.cpp). To resolve the issue we would like to add a small patch applied on RtpQueue that adds mutexes on pop() and push() operations.